### PR TITLE
fix(deps): dependabot の package-ecosystem を bun に変更

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
-  # npm パッケージ
-  - package-ecosystem: "npm"
+  # bun パッケージ
+  - package-ecosystem: "bun"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## 概要

dependabot の `package-ecosystem` を `npm` から `bun` に変更します。

## 問題

- dependabot が package.json を更新するが、bun.lock を更新しない
- CI で `bun install --frozen-lockfile` が失敗する（PR #3）

## 原因

`package-ecosystem: "npm"` では bun.lock が認識されないため、ロックファイルが更新されませんでした。

## 解決策

Dependabot は [2025年2月13日に bun を正式サポート](https://github.blog/changelog/2025-02-13-dependabot-version-updates-now-support-the-bun-package-manager-ga/) しました。
`package-ecosystem: "bun"` に変更することで、bun.lock も正しく更新されるようになります。

## テスト方法

1. このPRをマージ
2. 既存のPR #3 をクローズ
3. dependabot が新しいPRを作成するのを待つ（または手動で実行）
4. 新しいPRで bun.lock も更新されていることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)