### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/toku345/briefer/security/code-scanning/1](https://github.com/toku345/briefer/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` block to the workflow (either at the root or under the `check` job) and set it to the least privilege required. This job only checks out code and runs dependency installation, linting, type-checking, and tests; it doesn’t need to write to the repo or modify issues/PRs. Therefore, setting `contents: read` at the workflow level is sufficient and aligns with the CodeQL suggestion.

The best way to fix this without changing behavior is to add a top-level `permissions` block after the `on:` section (lines 3–7), so it applies to all jobs by default. Specifically, in `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `jobs:` block. No additional imports or definitions are needed, as this is pure workflow configuration. This will constrain the `GITHUB_TOKEN` to read-only repository contents for this workflow while preserving all existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
