### PR TITLE
Remove grouped updates from Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,6 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 3
-    groups:
-      dev-dependencies:
-        dependency-type: "development"
     commit-message:
       prefix: "chore(deps)"
 


### PR DESCRIPTION
Remove the `groups` section from the bun package ecosystem configuration in `dependabot.yml`.

Previously, development dependencies were grouped into a single PR. This change makes Dependabot create separate PRs for each dependency update, making it easier to review and manage individual updates.