### PR TITLE
refactor: decouple stall timeout detection from AbortError propagation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,7 @@ Managed by `lib/settings-store.ts`. Server URL (default: `http://localhost:8000/
 - Timer tests: `vi.useFakeTimers({ shouldAdvanceTime: true })` + `vi.advanceTimersByTimeAsync()`
 - Hook tests: `renderHook()` + `waitFor()` / `act()` for async state updates
 - Hooks using React Query must be wrapped with `QueryClientProvider`
+- Abort-aware mock generators: use `resolve()` on abort (not `reject(DOMException)`) to match `streamChat`'s silent-return behavior
 
 ## Chrome Extension Gotchas
 
@@ -95,3 +96,4 @@ Managed by `lib/settings-store.ts`. Server URL (default: `http://localhost:8000/
 - Always call `removeListener` in cleanup for `chrome.storage.onChanged.addListener`
 - `getSettings()` merges defaults with stored settings via `{ ...DEFAULT_SETTINGS, ...stored }` (`lib/settings-store.ts`)
 - Icon buttons require `aria-label` + `title`; SVGs require `aria-hidden="true"`
+- `streamChat` (async generator) is silent-return on AbortError — callers check state flags (e.g. `stallTimedOut`) after iteration, not in `catch`

--- a/entrypoints/sidepanel/hooks/useChatStream.ts
+++ b/entrypoints/sidepanel/hooks/useChatStream.ts
@@ -100,6 +100,11 @@ export function useChatStream(tabId: number | null, pageContent: ExtractedConten
           }
         }
 
+        if (stallTimedOut) {
+          setError(STALL_TIMEOUT_MESSAGE);
+          didFail = true;
+        }
+
         const remaining = filter.flush();
         if (remaining) {
           fullResponse += remaining;
@@ -127,15 +132,9 @@ export function useChatStream(tabId: number | null, pageContent: ExtractedConten
           }
         }
       } catch (err) {
-        if (!controller.signal.aborted) {
-          console.error('[useChatStream] Stream error:', err);
-          setError(err instanceof Error ? err.message : 'エラーが発生しました');
-          didFail = true;
-        } else if (stallTimedOut) {
-          setError(STALL_TIMEOUT_MESSAGE);
-          didFail = true;
-        }
-        // ユーザーキャンセル（aborted && !stallTimedOut）→ エラーなし
+        console.error('[useChatStream] Stream error:', err);
+        setError(err instanceof Error ? err.message : 'エラーが発生しました');
+        didFail = true;
       } finally {
         if (stallTimerId !== undefined) clearTimeout(stallTimerId);
         if (abortRef.current === controller) {

--- a/lib/llm-client.ts
+++ b/lib/llm-client.ts
@@ -214,20 +214,3 @@ export async function* streamChat(
     reader.releaseLock();
   }
 }
-
-export async function chat(
-  messages: ChatMessage[],
-  pageContent: ExtractedContent,
-  model: string,
-  signal?: AbortSignal,
-): Promise<string> {
-  let result = '';
-  for await (const chunk of streamChat(messages, pageContent, model, signal)) {
-    if (chunk.type === 'chunk' && chunk.content) {
-      result += chunk.content;
-    } else if (chunk.type === 'error') {
-      throw new Error(chunk.error);
-    }
-  }
-  return result;
-}

--- a/lib/llm-client.ts
+++ b/lib/llm-client.ts
@@ -147,7 +147,7 @@ export async function* streamChat(
       signal,
     });
   } catch (error) {
-    if (error instanceof DOMException && error.name === 'AbortError') throw error;
+    if (error instanceof DOMException && error.name === 'AbortError') return;
     console.error('[streamChat] Fetch failed:', error);
     yield {
       type: 'error',
@@ -204,7 +204,7 @@ export async function* streamChat(
 
     yield { type: 'done', modelId: model };
   } catch (error) {
-    if (error instanceof DOMException && error.name === 'AbortError') throw error;
+    if (error instanceof DOMException && error.name === 'AbortError') return;
     console.error('[streamChat] Stream read failed:', error);
     yield {
       type: 'error',

--- a/tests/llm-client.test.ts
+++ b/tests/llm-client.test.ts
@@ -251,7 +251,7 @@ describe('llm-client', () => {
       expect(chunks).toContainEqual({ type: 'error', error: 'No response body' });
     });
 
-    it('AbortSignalによるキャンセルでAbortErrorをthrowする', async () => {
+    it('AbortSignalによるキャンセルでsilent returnする', async () => {
       const controller = new AbortController();
 
       mockFetch.mockImplementationOnce(async (_url: string, init?: RequestInit) => {
@@ -277,19 +277,16 @@ describe('llm-client', () => {
       const messages: ChatMessage[] = [{ role: 'user', content: 'test' }];
       const chunks: StreamChunk[] = [];
 
-      await expect(
-        (async () => {
-          for await (const chunk of streamChat(
-            messages,
-            mockPageContent,
-            TEST_MODEL,
-            controller.signal,
-          )) {
-            chunks.push(chunk);
-            if (chunk.type === 'chunk') controller.abort();
-          }
-        })(),
-      ).rejects.toMatchObject({ name: 'AbortError' });
+      for await (const chunk of streamChat(
+        messages,
+        mockPageContent,
+        TEST_MODEL,
+        controller.signal,
+      )) {
+        chunks.push(chunk);
+        if (chunk.type === 'chunk') controller.abort();
+      }
+
       expect(chunks).toEqual([{ type: 'chunk', content: 'start' }]);
     });
 
@@ -306,26 +303,25 @@ describe('llm-client', () => {
       expect(chunks[0]).toEqual({ type: 'error', error: 'Failed to fetch' });
     });
 
-    it('fetch失敗時にAbortErrorならthrowする', async () => {
+    it('fetch失敗時にAbortErrorならsilent returnする', async () => {
       const controller = new AbortController();
       controller.abort();
 
       mockFetch.mockRejectedValue(new DOMException('Aborted', 'AbortError'));
 
       const messages: ChatMessage[] = [{ role: 'user', content: 'test' }];
+      const chunks: StreamChunk[] = [];
 
-      await expect(
-        (async () => {
-          for await (const _chunk of streamChat(
-            messages,
-            mockPageContent,
-            TEST_MODEL,
-            controller.signal,
-          )) {
-            // consume
-          }
-        })(),
-      ).rejects.toMatchObject({ name: 'AbortError' });
+      for await (const chunk of streamChat(
+        messages,
+        mockPageContent,
+        TEST_MODEL,
+        controller.signal,
+      )) {
+        chunks.push(chunk);
+      }
+
+      expect(chunks).toEqual([]);
     });
 
     it('getSettings失敗時にyield経路でエラーを返す', async () => {

--- a/tests/llm-client.test.ts
+++ b/tests/llm-client.test.ts
@@ -24,7 +24,7 @@ const mockChrome = {
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
-const { buildSystemMessage, chat, fetchModels, streamChat } = await import('../lib/llm-client');
+const { buildSystemMessage, fetchModels, streamChat } = await import('../lib/llm-client');
 
 describe('llm-client', () => {
   const mockPageContent: ExtractedContent = {
@@ -120,97 +120,6 @@ describe('llm-client', () => {
       expect(mockFetch).toHaveBeenCalledWith('http://explicit:8000/v1/models', {
         signal: undefined,
       });
-    });
-  });
-
-  describe('chat', () => {
-    it('設定のURLでAPIを呼び出す', async () => {
-      mockLocalStorage[SETTINGS_KEY] = { serverUrl: 'http://myserver:8000/v1' };
-
-      const mockStream = new ReadableStream({
-        start(controller) {
-          controller.enqueue(
-            new TextEncoder().encode('data: {"choices":[{"delta":{"content":"OK"}}]}\n'),
-          );
-          controller.enqueue(new TextEncoder().encode('data: [DONE]\n'));
-          controller.close();
-        },
-      });
-
-      mockFetch.mockResolvedValue({ ok: true, body: mockStream });
-
-      const messages: ChatMessage[] = [{ role: 'user', content: '要約して' }];
-      const result = await chat(messages, mockPageContent, TEST_MODEL);
-
-      expect(result).toBe('OK');
-      expect(mockFetch).toHaveBeenCalledWith(
-        'http://myserver:8000/v1/chat/completions',
-        expect.objectContaining({
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-        }),
-      );
-    });
-
-    it('設定のtemperatureとmaxTokensを使用する', async () => {
-      mockLocalStorage[SETTINGS_KEY] = { temperature: 0.8, maxTokens: 4096 };
-
-      const mockStream = new ReadableStream({
-        start(controller) {
-          controller.enqueue(new TextEncoder().encode('data: [DONE]\n'));
-          controller.close();
-        },
-      });
-
-      mockFetch.mockResolvedValue({ ok: true, body: mockStream });
-
-      const messages: ChatMessage[] = [{ role: 'user', content: 'test' }];
-      await chat(messages, mockPageContent, TEST_MODEL);
-
-      const callArgs = mockFetch.mock.calls[0];
-      const body = JSON.parse(callArgs[1].body);
-
-      expect(body.temperature).toBe(0.8);
-      expect(body.max_tokens).toBe(4096);
-    });
-
-    it('APIエラー時に例外をスローする', async () => {
-      mockFetch.mockResolvedValue({
-        ok: false,
-        status: 500,
-        statusText: 'Internal Server Error',
-        body: null,
-      });
-
-      const messages: ChatMessage[] = [{ role: 'user', content: '要約して' }];
-
-      await expect(chat(messages, mockPageContent, TEST_MODEL)).rejects.toThrow('API error: 500');
-    });
-
-    it('modelIdを含むメッセージからAPIリクエスト時にmodelIdを除外する', async () => {
-      const mockStream = new ReadableStream({
-        start(controller) {
-          controller.enqueue(new TextEncoder().encode('data: [DONE]\n'));
-          controller.close();
-        },
-      });
-
-      mockFetch.mockResolvedValue({ ok: true, body: mockStream });
-
-      const messages: ChatMessage[] = [
-        { role: 'user', content: '要約して' },
-        { role: 'assistant', content: '要約です', modelId: 'org/some-model' },
-        { role: 'user', content: '続けて' },
-      ];
-
-      await chat(messages, mockPageContent, TEST_MODEL);
-
-      const callArgs = mockFetch.mock.calls[0];
-      const body = JSON.parse(callArgs[1].body);
-
-      for (const msg of body.messages) {
-        expect(msg).not.toHaveProperty('modelId');
-      }
     });
   });
 
@@ -392,6 +301,106 @@ describe('llm-client', () => {
       const contentChunks = chunks.filter((c) => c.type === 'chunk');
       expect(contentChunks).toHaveLength(1);
       expect(contentChunks[0]).toEqual({ type: 'chunk', content: 'text' });
+    });
+
+    it('設定のURLでAPIを呼び出す', async () => {
+      mockLocalStorage[SETTINGS_KEY] = { serverUrl: 'http://myserver:8000/v1' };
+
+      const mockStream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode('data: {"choices":[{"delta":{"content":"OK"}}]}\n'),
+          );
+          controller.enqueue(new TextEncoder().encode('data: [DONE]\n'));
+          controller.close();
+        },
+      });
+
+      mockFetch.mockResolvedValue({ ok: true, body: mockStream });
+
+      const messages: ChatMessage[] = [{ role: 'user', content: '要約して' }];
+      const chunks: StreamChunk[] = [];
+      for await (const chunk of streamChat(messages, mockPageContent, TEST_MODEL)) {
+        chunks.push(chunk);
+      }
+
+      expect(chunks).toContainEqual({ type: 'chunk', content: 'OK' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://myserver:8000/v1/chat/completions',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    });
+
+    it('設定のtemperatureとmaxTokensを使用する', async () => {
+      mockLocalStorage[SETTINGS_KEY] = { temperature: 0.8, maxTokens: 4096 };
+
+      const mockStream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('data: [DONE]\n'));
+          controller.close();
+        },
+      });
+
+      mockFetch.mockResolvedValue({ ok: true, body: mockStream });
+
+      const messages: ChatMessage[] = [{ role: 'user', content: 'test' }];
+      for await (const _ of streamChat(messages, mockPageContent, TEST_MODEL)) {
+        // drain
+      }
+
+      const callArgs = mockFetch.mock.calls[0];
+      const body = JSON.parse(callArgs[1].body);
+
+      expect(body.temperature).toBe(0.8);
+      expect(body.max_tokens).toBe(4096);
+    });
+
+    it('APIエラー時にerror chunkを返す', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        body: null,
+      });
+
+      const messages: ChatMessage[] = [{ role: 'user', content: '要約して' }];
+      const chunks: StreamChunk[] = [];
+      for await (const chunk of streamChat(messages, mockPageContent, TEST_MODEL)) {
+        chunks.push(chunk);
+      }
+
+      expect(chunks).toEqual([{ type: 'error', error: 'API error: 500 Internal Server Error' }]);
+    });
+
+    it('modelIdを含むメッセージからAPIリクエスト時にmodelIdを除外する', async () => {
+      const mockStream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('data: [DONE]\n'));
+          controller.close();
+        },
+      });
+
+      mockFetch.mockResolvedValue({ ok: true, body: mockStream });
+
+      const messages: ChatMessage[] = [
+        { role: 'user', content: '要約して' },
+        { role: 'assistant', content: '要約です', modelId: 'org/some-model' },
+        { role: 'user', content: '続けて' },
+      ];
+
+      for await (const _ of streamChat(messages, mockPageContent, TEST_MODEL)) {
+        // drain
+      }
+
+      const callArgs = mockFetch.mock.calls[0];
+      const body = JSON.parse(callArgs[1].body);
+
+      for (const msg of body.messages) {
+        expect(msg).not.toHaveProperty('modelId');
+      }
     });
   });
 });

--- a/tests/useChatStream.test.tsx
+++ b/tests/useChatStream.test.tsx
@@ -62,13 +62,13 @@ function createHangingStream(initialChunks: StreamChunk[] = []) {
       yield chunk;
     }
     // abort されるまで無限に待機
-    await new Promise<void>((_resolve, reject) => {
+    await new Promise<void>((resolve) => {
       if (signal?.aborted) {
-        reject(new DOMException('The operation was aborted.', 'AbortError'));
+        resolve();
         return;
       }
       signal?.addEventListener('abort', () => {
-        reject(new DOMException('The operation was aborted.', 'AbortError'));
+        resolve();
       });
     });
   };
@@ -171,22 +171,22 @@ describe('useChatStream stall detection', () => {
     mockStreamChat.mockImplementation(async function* (_m, _p, _model, signal) {
       yield { type: 'chunk' as const, content: 'first' };
       // INTER_TOKEN_TIMEOUT_MS 未満待機 → タイマーリセットされるはず
-      await new Promise<void>((resolve, reject) => {
+      await new Promise<void>((resolve) => {
         const timer = setTimeout(resolve, INTER_TOKEN_TIMEOUT_MS - 1000);
         signal?.addEventListener('abort', () => {
           clearTimeout(timer);
-          reject(new DOMException('aborted', 'AbortError'));
+          resolve();
         });
       });
       yield { type: 'chunk' as const, content: 'second' };
       // abort されるまで待機
-      await new Promise<void>((_resolve, reject) => {
+      await new Promise<void>((resolve) => {
         if (signal?.aborted) {
-          reject(new DOMException('aborted', 'AbortError'));
+          resolve();
           return;
         }
         signal?.addEventListener('abort', () => {
-          reject(new DOMException('aborted', 'AbortError'));
+          resolve();
         });
       });
     });


### PR DESCRIPTION
Closes #45

## Summary
- `streamChat` now silent-returns on `AbortError` instead of throwing, making abort handling consistent with the yield-based error strategy
- `useChatStream` checks the `stallTimedOut` flag after the `for-await` loop instead of inside the `catch` block, decoupling stall detection from exception propagation
- The `catch` block in `useChatStream` is simplified to a safety net for truly unexpected errors

## Test plan
- [x] `bun run test` — 245 tests pass
- [x] `bun run typecheck` — no errors
- [x] `bun run check` — no lint/format issues
- [x] Abort tests updated to verify silent return (no thrown AbortError)
- [x] Stall detection tests continue to pass with resolve-based mock generators

🤖 Generated with [Claude Code](https://claude.com/claude-code)