### PR TITLE
feat: detect finish_reason length and show truncation warning

### DIFF
--- a/entrypoints/sidepanel/components/MessageBubble.tsx
+++ b/entrypoints/sidepanel/components/MessageBubble.tsx
@@ -16,6 +16,11 @@ export function MessageBubble({ message }: MessageBubbleProps) {
         <ErrorBoundary fallback={<span>{message.content}</span>}>
           <ReactMarkdown remarkPlugins={[remarkGfm]}>{message.content}</ReactMarkdown>
         </ErrorBoundary>
+        {message.truncated && (
+          <output className="truncation-warning">
+            出力がmax_tokensの上限に達したため途中で切れています。設定から上限を増やせます。
+          </output>
+        )}
       </div>
     );
   }

--- a/entrypoints/sidepanel/hooks/useChatStream.ts
+++ b/entrypoints/sidepanel/hooks/useChatStream.ts
@@ -68,6 +68,7 @@ export function useChatStream(tabId: number | null, pageContent: ExtractedConten
       let fullResponse = '';
       let didFail = false;
       let stallTimedOut = false;
+      let finishReason: string | undefined;
       let stallTimerId: ReturnType<typeof setTimeout> | undefined;
       const filter = new ThinkTagFilter();
 
@@ -93,6 +94,8 @@ export function useChatStream(tabId: number | null, pageContent: ExtractedConten
             if (filtered) {
               setStreamingContent((prev) => prev + filtered);
             }
+          } else if (chunk.type === 'done') {
+            finishReason = chunk.finishReason;
           } else if (chunk.type === 'error') {
             setError(chunk.error);
             didFail = true;
@@ -116,6 +119,7 @@ export function useChatStream(tabId: number | null, pageContent: ExtractedConten
             role: 'assistant',
             content: fullResponse,
             modelId: model,
+            ...(finishReason === 'length' && { truncated: true }),
           };
 
           const updatedMessages = [...allMessages, assistantMessage];

--- a/entrypoints/sidepanel/style.css
+++ b/entrypoints/sidepanel/style.css
@@ -571,6 +571,14 @@ body {
   background: #661111;
 }
 
+.truncation-warning {
+  color: #ffd866;
+  font-size: 12px;
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid #555;
+}
+
 .error-fallback {
   padding: 20px;
   text-align: center;

--- a/lib/llm-client.ts
+++ b/lib/llm-client.ts
@@ -172,6 +172,7 @@ export async function* streamChat(
 
   const decoder = new TextDecoder();
   let buffer = '';
+  let lastFinishReason: string | undefined;
 
   try {
     while (true) {
@@ -192,6 +193,10 @@ export async function* streamChat(
           if (!json || typeof json !== 'object' || !Array.isArray(json.choices)) {
             continue;
           }
+          const finishReason = json.choices[0]?.finish_reason;
+          if (typeof finishReason === 'string') {
+            lastFinishReason = finishReason;
+          }
           const content = json.choices[0]?.delta?.content;
           if (typeof content === 'string' && content) {
             yield { type: 'chunk', content };
@@ -202,7 +207,7 @@ export async function* streamChat(
       }
     }
 
-    yield { type: 'done', modelId: model };
+    yield { type: 'done', modelId: model, finishReason: lastFinishReason };
   } catch (error) {
     if (error instanceof DOMException && error.name === 'AbortError') return;
     console.error('[streamChat] Stream read failed:', error);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -20,6 +20,8 @@ export interface ChatMessage {
   content: string;
   /** アシスタントメッセージ生成時に使用されたモデルID */
   modelId?: string;
+  /** max_tokensに到達して出力が途中で切れた場合にtrue */
+  truncated?: boolean;
 }
 
 export interface ChatState {
@@ -29,7 +31,7 @@ export interface ChatState {
 
 export type StreamChunk =
   | { type: 'chunk'; content: string }
-  | { type: 'done'; modelId: string }
+  | { type: 'done'; modelId: string; finishReason?: string }
   | { type: 'error'; error: string };
 
 export const SETTINGS_KEY = 'briefer_settings';

--- a/tests/MessageBubble.test.tsx
+++ b/tests/MessageBubble.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { MessageBubble } from '../entrypoints/sidepanel/components/MessageBubble';
+import type { ChatMessage } from '../lib/types';
+
+describe('MessageBubble', () => {
+  it('truncated: true のassistantメッセージに警告を表示する', () => {
+    const message: ChatMessage = {
+      role: 'assistant',
+      content: 'partial output',
+      truncated: true,
+    };
+
+    render(<MessageBubble message={message} />);
+
+    expect(screen.getByText(/max_tokensの上限に達した/)).not.toBeNull();
+  });
+
+  it('truncated でないassistantメッセージに警告を表示しない', () => {
+    const message: ChatMessage = {
+      role: 'assistant',
+      content: 'full output',
+    };
+
+    render(<MessageBubble message={message} />);
+
+    expect(screen.queryByText(/max_tokensの上限に達した/)).toBeNull();
+  });
+
+  it('userメッセージにはtruncated警告を表示しない', () => {
+    const message: ChatMessage = {
+      role: 'user',
+      content: 'hello',
+    };
+
+    render(<MessageBubble message={message} />);
+
+    expect(screen.queryByText(/max_tokensの上限に達した/)).toBeNull();
+  });
+});

--- a/tests/llm-client.test.ts
+++ b/tests/llm-client.test.ts
@@ -436,7 +436,7 @@ describe('llm-client', () => {
       expect(chunks).toEqual([{ type: 'error', error: 'API error: 500 Internal Server Error' }]);
     });
 
-    it('modelIdを含むメッセージからAPIリクエスト時にmodelIdを除外する', async () => {
+    it('modelId・truncatedを含むメッセージからAPIリクエスト時にこれらを除外する', async () => {
       const mockStream = new ReadableStream({
         start(controller) {
           controller.enqueue(new TextEncoder().encode('data: [DONE]\n'));
@@ -448,7 +448,7 @@ describe('llm-client', () => {
 
       const messages: ChatMessage[] = [
         { role: 'user', content: '要約して' },
-        { role: 'assistant', content: '要約です', modelId: 'org/some-model' },
+        { role: 'assistant', content: '要約です', modelId: 'org/some-model', truncated: true },
         { role: 'user', content: '続けて' },
       ];
 
@@ -461,6 +461,7 @@ describe('llm-client', () => {
 
       for (const msg of body.messages) {
         expect(msg).not.toHaveProperty('modelId');
+        expect(msg).not.toHaveProperty('truncated');
       }
     });
   });

--- a/tests/llm-client.test.ts
+++ b/tests/llm-client.test.ts
@@ -145,9 +145,7 @@ describe('llm-client', () => {
       }
 
       expect(chunks).toContainEqual({ type: 'chunk', content: 'OK' });
-      expect(chunks).toContainEqual(
-        expect.objectContaining({ type: 'done', modelId: TEST_MODEL }),
-      );
+      expect(chunks).toContainEqual(expect.objectContaining({ type: 'done', modelId: TEST_MODEL }));
     });
 
     it('finish_reason: "length" をdoneチャンクに含める', async () => {
@@ -159,9 +157,7 @@ describe('llm-client', () => {
             ),
           );
           controller.enqueue(
-            new TextEncoder().encode(
-              'data: {"choices":[{"delta":{},"finish_reason":"length"}]}\n',
-            ),
+            new TextEncoder().encode('data: {"choices":[{"delta":{},"finish_reason":"length"}]}\n'),
           );
           controller.enqueue(new TextEncoder().encode('data: [DONE]\n'));
           controller.close();

--- a/tests/llm-client.test.ts
+++ b/tests/llm-client.test.ts
@@ -145,7 +145,72 @@ describe('llm-client', () => {
       }
 
       expect(chunks).toContainEqual({ type: 'chunk', content: 'OK' });
-      expect(chunks).toContainEqual({ type: 'done', modelId: TEST_MODEL });
+      expect(chunks).toContainEqual(
+        expect.objectContaining({ type: 'done', modelId: TEST_MODEL }),
+      );
+    });
+
+    it('finish_reason: "length" をdoneチャンクに含める', async () => {
+      const mockStream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode(
+              'data: {"choices":[{"delta":{"content":"text"},"finish_reason":null}]}\n',
+            ),
+          );
+          controller.enqueue(
+            new TextEncoder().encode(
+              'data: {"choices":[{"delta":{},"finish_reason":"length"}]}\n',
+            ),
+          );
+          controller.enqueue(new TextEncoder().encode('data: [DONE]\n'));
+          controller.close();
+        },
+      });
+
+      mockFetch.mockResolvedValue({ ok: true, body: mockStream });
+
+      const messages: ChatMessage[] = [{ role: 'user', content: 'test' }];
+      const chunks: StreamChunk[] = [];
+      for await (const chunk of streamChat(messages, mockPageContent, TEST_MODEL)) {
+        chunks.push(chunk);
+      }
+
+      const doneChunk = chunks.find((c) => c.type === 'done');
+      expect(doneChunk).toEqual({
+        type: 'done',
+        modelId: TEST_MODEL,
+        finishReason: 'length',
+      });
+    });
+
+    it('finish_reason: "stop" をdoneチャンクに含める', async () => {
+      const mockStream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode(
+              'data: {"choices":[{"delta":{"content":"done"},"finish_reason":"stop"}]}\n',
+            ),
+          );
+          controller.enqueue(new TextEncoder().encode('data: [DONE]\n'));
+          controller.close();
+        },
+      });
+
+      mockFetch.mockResolvedValue({ ok: true, body: mockStream });
+
+      const messages: ChatMessage[] = [{ role: 'user', content: 'test' }];
+      const chunks: StreamChunk[] = [];
+      for await (const chunk of streamChat(messages, mockPageContent, TEST_MODEL)) {
+        chunks.push(chunk);
+      }
+
+      const doneChunk = chunks.find((c) => c.type === 'done');
+      expect(doneChunk).toEqual({
+        type: 'done',
+        modelId: TEST_MODEL,
+        finishReason: 'stop',
+      });
     });
 
     it('レスポンスボディがない場合はエラーを返す', async () => {

--- a/tests/useChatStream.test.tsx
+++ b/tests/useChatStream.test.tsx
@@ -5,7 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { ChatState, StreamChunk } from '../lib/types';
+import type { ChatMessage, ChatState, StreamChunk } from '../lib/types';
 
 vi.mock('@/lib/llm-client', () => ({
   streamChat: vi.fn(),
@@ -354,11 +354,11 @@ describe('useChatStream truncation detection', () => {
     });
 
     expect(mockChrome.storage.session.set).toHaveBeenCalled();
-    const setCall = mockChrome.storage.session.set.mock.calls[0][0];
-    const persistedMessages = setCall.chat_1;
-    const assistantMsg = persistedMessages.find(
-      (m: { role: string }) => m.role === 'assistant',
-    );
+    const setCall = mockChrome.storage.session.set.mock.calls[0] as unknown as [
+      Record<string, ChatMessage[]>,
+    ];
+    const persistedMessages = setCall[0].chat_1;
+    const assistantMsg = persistedMessages.find((m: { role: string }) => m.role === 'assistant');
     expect(assistantMsg?.truncated).toBe(true);
   });
 });

--- a/tests/useChatStream.test.tsx
+++ b/tests/useChatStream.test.tsx
@@ -298,6 +298,71 @@ describe('useChatStream retry', () => {
   });
 });
 
+describe('useChatStream truncation detection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('finish_reason: "length" 時にassistantメッセージにtruncated: trueが設定される', async () => {
+    mockStreamChat.mockImplementation(async function* () {
+      yield { type: 'chunk' as const, content: 'partial output' };
+      yield { type: 'done' as const, modelId: 'test-model', finishReason: 'length' };
+    });
+
+    const { queryClient, wrapper } = createWrapper();
+    const { result } = renderHook(() => useChatStream(1, pageContent), { wrapper });
+
+    await act(async () => {
+      await result.current.sendMessage('hello');
+    });
+
+    const state = queryClient.getQueryData<ChatState>(['chat', 1]);
+    const assistantMsg = state?.messages.find((m) => m.role === 'assistant');
+    expect(assistantMsg?.truncated).toBe(true);
+    expect(assistantMsg?.content).toBe('partial output');
+  });
+
+  it('finish_reason: "stop" 時にtruncatedが設定されない', async () => {
+    mockStreamChat.mockImplementation(async function* () {
+      yield { type: 'chunk' as const, content: 'full output' };
+      yield { type: 'done' as const, modelId: 'test-model', finishReason: 'stop' };
+    });
+
+    const { queryClient, wrapper } = createWrapper();
+    const { result } = renderHook(() => useChatStream(1, pageContent), { wrapper });
+
+    await act(async () => {
+      await result.current.sendMessage('hello');
+    });
+
+    const state = queryClient.getQueryData<ChatState>(['chat', 1]);
+    const assistantMsg = state?.messages.find((m) => m.role === 'assistant');
+    expect(assistantMsg?.truncated).toBeUndefined();
+  });
+
+  it('truncatedメッセージがsession storageに永続化される', async () => {
+    mockStreamChat.mockImplementation(async function* () {
+      yield { type: 'chunk' as const, content: 'truncated' };
+      yield { type: 'done' as const, modelId: 'test-model', finishReason: 'length' };
+    });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useChatStream(1, pageContent), { wrapper });
+
+    await act(async () => {
+      await result.current.sendMessage('hello');
+    });
+
+    expect(mockChrome.storage.session.set).toHaveBeenCalled();
+    const setCall = mockChrome.storage.session.set.mock.calls[0][0];
+    const persistedMessages = setCall.chat_1;
+    const assistantMsg = persistedMessages.find(
+      (m: { role: string }) => m.role === 'assistant',
+    );
+    expect(assistantMsg?.truncated).toBe(true);
+  });
+});
+
 describe('useChatStream partial response preservation', () => {
   beforeEach(() => {
     vi.clearAllMocks();


### PR DESCRIPTION
## Summary
- Extract `finish_reason` from vLLM SSE stream chunks and propagate it through `StreamChunk`
- Detect `finish_reason: "length"` (max_tokens reached) and persist `truncated: true` on the assistant `ChatMessage`
- Display an inline warning below truncated messages in `MessageBubble`, surviving panel re-open
- Add 8 new tests covering finish_reason parsing, truncation flag persistence, and warning rendering

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run check` passes
- [x] `bun run test` passes (253 tests, 21 files)
- [ ] Manual: send a long prompt with low `max_tokens` (e.g. 50) → verify yellow warning appears below the truncated response
- [ ] Manual: re-open side panel → verify the warning persists on the truncated message
- [ ] Manual: normal completion (`finish_reason: "stop"`) → verify no warning appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)